### PR TITLE
Update homebrew tap for Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
-## 4.9002.0 - 2020-01-15
+## Unreleased
+### 4.9002.0 - Roblox internal
+
 - Based on proposed changes from <https://github.com/sous-chefs/java/pull/567/>
 - Switch homebrew tap to homebrew/cask-versions
 - Make Homebrew Tap name an attribute to allow for other options
 
-## 4.9001.0 - 2019-05-23
+### 4.9001.0 - Roblox internal
 
 - Make Homebrew Cask name an attribute to allow for other options (ex: adoptopenjdk)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 This file is used to list changes made in each version of the Java cookbook.
 
-## Unreleased
+## 4.9002.0 - 2020-01-15
+- Based on proposed changes from <https://github.com/sous-chefs/java/pull/567/>
+- Switch homebrew tap to homebrew/cask-versions
+- Make Homebrew Tap name an attribute to allow for other options
+
+## 4.9001.0 - 2019-05-23
 
 - Make Homebrew Cask name an attribute to allow for other options (ex: adoptopenjdk)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,7 @@ when 'windows'
   default['java']['windows']['returns'] = 0
 when 'mac_os_x'
   default['java']['install_flavor'] = 'homebrew'
+  default['java']['homebrew']['tap'] = 'homebrew/cask-versions'
   default['java']['homebrew']['cask'] = 'java'
 else
   default['java']['install_flavor'] = 'openjdk'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Recipes and resources for installing Java and managing certificates'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '4.9001.0'
+version           '4.9002.0'
 
 supports 'debian'
 supports 'ubuntu'

--- a/recipes/homebrew.rb
+++ b/recipes/homebrew.rb
@@ -2,7 +2,7 @@ include_recipe 'homebrew'
 include_recipe 'homebrew::cask'
 include_recipe 'java::notify'
 
-homebrew_tap 'caskroom/versions'
+homebrew_tap node['java']['homebrew']['tap']
 homebrew_cask "#{node['java']['homebrew']['cask']}#{node['java']['jdk_version']}" do
   notifies :write, 'log[jdk-version-changed]', :immediately
 end


### PR DESCRIPTION
### Summary 

The continuation of #5 (can be closed when this PR is merged)

<https://github.com/sous-chefs/java/issues/566>: `caskroom/versions` was moved. Tap `homebrew/cask-versions` instead

### Description

* Based on proposed changes from sous-chefs#567
* Switch homebrew tap to homebrew/cask-versions
* Make Homebrew Tap name an attribute to allow for other options

### Issues Resolved

* sous-chefs/java#566
